### PR TITLE
Make build script respect CGO_ENABLED and build static binaries

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -20,7 +20,7 @@ do
     fi  
     echo "Building for $GOOS $GOARCH..."
 
-    GOOS=$GOOS GOARCH=$GOARCH go build -a -installsuffix cgo -o $output_name
+    GOOS=$GOOS GOARCH=$GOARCH CGO_ENABLED=$CGO_ENABLED go build -a -installsuffix cgo -o $output_name
 
     if [ $? -ne 0 ]; then
         echo 'An error has occurred! Aborting the script execution...'


### PR DESCRIPTION
This should fix #16 and make release binaries statically linked (and therefore work on Alpine like rest of Terraform plugins).